### PR TITLE
トップページ構成の変更

### DIFF
--- a/content/home/accomplishments.md
+++ b/content/home/accomplishments.md
@@ -3,7 +3,7 @@
 widget = "accomplishments"  # See https://sourcethemes.com/academic/docs/page-builder/
 headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
-weight = 50  # Order that this section will appear.
+weight = 20  # Order that this section will appear.
 
 title = "協会の成果"
 subtitle = ""

--- a/content/home/donation.md
+++ b/content/home/donation.md
@@ -3,7 +3,7 @@
 widget = "hero"  # See https://sourcethemes.com/academic/docs/page-builder/
 headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
-weight = 15  # Order that this section will appear.
+weight = 50  # Order that this section will appear.
 
 title = "寄付のお願い"
 

--- a/content/home/missions.md
+++ b/content/home/missions.md
@@ -1,7 +1,7 @@
 +++
 widget = "featurette"
 headless = true
-weight = 20
+weight = 10
 
 title = "協会の使命"
 


### PR DESCRIPTION
Closes #40
- 「協会の成果」の位置を上部へ上げる
- 寄付の項目を末尾に下げる