### PR TITLE
SNS の最新投稿をトップページに埋め込む

### DIFF
--- a/content/home/sns.html
+++ b/content/home/sns.html
@@ -1,0 +1,12 @@
+---
+widget: blank
+headless: true
+title: SNS
+# subtitle:
+weight: 60
+design:
+  # Choose how many columns the section has. Valid values: 1 or 2.
+  columns: '2'
+---
+<a class="twitter-timeline" data-width="320" data-height="500" data-dnt="true" href="https://twitter.com/aocsj1979?ref_src=twsrc%5Etfw">Tweets by aocsj1979</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Faocsj1979%2F&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=613086300107345" width="340" height="500" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>


### PR DESCRIPTION
Resolves #84

Instagram のウィジェットの作成にはサーバーサイドの実装が必要になり，CSS の準備も必要で時間がかかるため今回は行わない．
サーバーレスで実装できそう．参考: https://arts-factory.net/insta_api/
